### PR TITLE
PG/Lv1/하샤드 수

### DIFF
--- a/PG/Lv1/하샤드 수.js
+++ b/PG/Lv1/하샤드 수.js
@@ -1,0 +1,4 @@
+function solution(x) { 
+  const sum = (x + "").split("").reduce((acc, cur) => acc + (+cur), 0);
+  return x % sum === 0;
+}


### PR DESCRIPTION
## 문제
- close #64 
- https://school.programmers.co.kr/learn/courses/30/lessons/12947

## 후기
문자열 배열에 reduce를 사용하고 초기값을 생략한 채로 acc과 cur을 더했더니 문자열의 덧셈이 이루어졌다.
알고보니 reduce의 초기값을 생략하면 인덱스 0이 acc에 누적되고 인덱스 1부터 시작되는 거였다.
acc에 문자열이 들어갔으니 다음 덧셈부터는 문자열 덧셈이 이루어져 값이 이상하게 나왔다.
reduce의 초기값에 대해 찾아본 결과 초기값은 생략하지 않다는 것을 알게 되었다. 