### PR TITLE
PG/Lv1/신규 아이디 추천 (정규표현식)

### DIFF
--- a/PG/Lv1/신규 아이디 추천.js
+++ b/PG/Lv1/신규 아이디 추천.js
@@ -1,0 +1,11 @@
+function solution(new_id) {
+  new_id = new_id.toLowerCase();
+  new_id = new_id.match(/[a-z0-9\-\_\.]/g).join('');
+  new_id = new_id.replace(/\.{2,}/g, '.')
+  new_id = new_id.replace(/^\.|\.$/, '');
+  new_id = new_id.length === 0 ? 'a' : new_id;
+  new_id = new_id.length >= 16 ? new_id.slice(0, 15) : new_id; 
+  new_id = new_id.replace(/\.$/, ''); 
+  new_id = new_id.length <= 2 ? new_id.padEnd(3, new_id.slice(-1)) : new_id;
+  return new_id;
+}

--- a/PG/Lv1/신규 아이디 추천.js
+++ b/PG/Lv1/신규 아이디 추천.js
@@ -1,11 +1,11 @@
 function solution(new_id) {
-  new_id = new_id.toLowerCase();
-  new_id = new_id.match(/[a-z0-9\-\_\.]/g).join('');
-  new_id = new_id.replace(/\.{2,}/g, '.')
-  new_id = new_id.replace(/^\.|\.$/, '');
-  new_id = new_id.length === 0 ? 'a' : new_id;
-  new_id = new_id.length >= 16 ? new_id.slice(0, 15) : new_id; 
-  new_id = new_id.replace(/\.$/, ''); 
-  new_id = new_id.length <= 2 ? new_id.padEnd(3, new_id.slice(-1)) : new_id;
-  return new_id;
+  let id = new_id
+    .toLowerCase()
+    .replace(/[^\w\d-_.]/g, "")
+    .replace(/\.{2,}/g, ".")
+    .replace(/^\.|\.$/, "")
+    .padEnd(1, "a")
+    .slice(0, 15)
+    .replace(/\.$/, "");
+  return id.padEnd(3, id.slice(-1));
 }


### PR DESCRIPTION
## 문제
- close #105 
- https://school.programmers.co.kr/learn/courses/30/lessons/72410

## 공부한 개념
- 정규표현식

## 참고 레퍼런스
- [[자바스크립트] 정규표현식(Regular Expression) 기초/기본 쉽고 상세한 사용 방법 정리(샘플 예제 코드)](https://curryyou.tistory.com/234)
- [[JS] 📚 정규표현식(RegExp) - 이해하기 쉽게 정리 + 응용 예제](https://inpa.tistory.com/entry/JS-%F0%9F%93%9A-%EC%A0%95%EA%B7%9C%EC%8B%9D-RegExp-%EB%88%84%EA%B5%AC%EB%82%98-%EC%9D%B4%ED%95%B4%ED%95%98%EA%B8%B0-%EC%89%BD%EA%B2%8C-%EC%A0%95%EB%A6%AC)
- [[regex] 정규식 빈 문자열 또는 이메일](http://daplus.net/regex-%EC%A0%95%EA%B7%9C%EC%8B%9D-%EB%B9%88-%EB%AC%B8%EC%9E%90%EC%97%B4-%EB%98%90%EB%8A%94-%EC%9D%B4%EB%A9%94%EC%9D%BC/)

## 후기
정규식을 사용하지 않고 풀어보려고 했는데 문자가 알파벳인지 아닌지 판별하는 부분에서 막혀서 그냥 정규식을 사용했다.
그러다 다른 사람 풀이를 보고 `'abcdefghijklmnopqrstuvwxyz'.indexOf('a')` 이런식으로 판별하는 방법이 있다는 것을 알았다. 

내가 사용한 정규표현식과 다른 사람이 사용한 정규표현식을 비교해보겠다.

[조건] new_id에서 알파벳 소문자, 숫자, 빼기(-), 밑줄(_), 마침표(.)를 제외한 모든 문자를 제거
나: `/[a-z0-9\-\_\.]/g`
다른 사람: `/[^\w\d-_.]/g`

나는 match를 이용해서 정규표현식에 매칭되는 항목들만 배열로 반환한 뒤 join('')을 사용하여 문자열로 만들었다.
다른 사람은 replace를 사용했고, [^문자]를 사용하여 괄호 안의 문자를 제외한 것들을 공백으로 바꿔줬다. 
또 다른 점은 나는 소문자와 숫자를 a-z0-9로 나타냈는데 **\w\d**로 나타낼 수 있는 것을 알았다. 
그리고 특수문자 앞에 이스케이프 문자(\)를 붙여줘야 한다고 생각했는데 안 붙여도 잘 돌아가는 것 같다..

그리고 new_id 배열의 길이에 따라 문자열을 자르거나 채우거나 'a'를 넣는 조건은 삼항 연산자를 사용해서 비교할 필요가 없다는 것을 알았다. 
길이가 16보다 클 때 15글자만큼 자르는 건 어차피 길이가 16 미만일 때 slice(0, 15)를 한다 해도 잘리지 않고, padEnd를 사용하여 문자를 채우는 것은 default값 느낌으로 생각해도 되는 것 같다. 

그리고 **빈 문자열과 일치하는 정규표현식**은 `^$`라고 한다. 
padEnd를 사용하여 빈 문자열일 때 'a'를 채우는 방식도 있지만 `replace(/^$/, 'a')` 이렇게 작성하는 방법도 있다.
