### PR TITLE
PG/Lv2/문자열 압축

### DIFF
--- a/PG/Lv2/문자열 압축.js
+++ b/PG/Lv2/문자열 압축.js
@@ -1,0 +1,21 @@
+function solution(s) {
+  let min = s.length;
+
+  for (let i = 1; i <= Math.floor(s.length / 2); i++) {
+      let tmp = s.slice(0, i);
+      let answer = '';
+      let count = 1;
+      for (let j = i; j < s.length; j += i) {
+          let now = s.slice(j, j + i);
+          if (tmp === now) count += 1;
+          else {
+              answer += count !== 1 ? count + tmp : tmp;
+              count = 1;
+              tmp = now;
+          }
+      }
+      answer += count !== 1 ? count + tmp : tmp;
+      if (answer.length < min) min = answer.length;
+  }
+  return min;
+}


### PR DESCRIPTION
## 문제
- close #125 
- https://school.programmers.co.kr/learn/courses/30/lessons/60057

## 공부한 개념
- slice()의 end 값이 배열의 길이보다 크다면, slice()는 배열의 끝까지(arr.length) 추출한다.
```c
const str = 'abc';
console.log(str.slice(0, 5)); // abc
```

## 참고 레퍼런스
- [Array.prototype.slice()](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/slice)

## 후기
s가 `abcabcdede`와 같을 때 문자열을 3개 단위로 잘라서 압축하면 딱 맞아 떨어지지 않아서 그런 부분을 어떻게 처리해야 할까 고민했었는데 slice()의 end가 배열 길이보다 더 클 때 배열 끝까지 추출하는 것을 이용하면 비교적 쉽게 풀 수 있다. 
사실 처음부터 알았던 것은 아닌데 풀다가 이게 왜 에러가 안나지? 하고 콘솔에 찍어보고 알았다.
나중에 한 번 더 풀어봐도 좋을 것 같다. 