### PR TITLE
PG/Lv2/피보나치 수

### DIFF
--- a/PG/Lv2/피보나치 수.js
+++ b/PG/Lv2/피보나치 수.js
@@ -1,15 +1,9 @@
-function fibo(n, memo) {
-  if (n === 0 || n === 1) return n;
-
-  if (memo[n - 1] === -1) memo[n - 1] = fibo(n - 1, memo);
-  if (memo[n - 2] === -1) memo[n - 2] = fibo(n - 2, memo);
-  
-  return (memo[n - 1] % 1234567 + memo[n - 2] % 1234567) % 1234567;
-}
-
 function solution(n) {
-  let memo = Array.from({length: n}, () => -1);
-  memo[0] = 0;
-  memo[1] = 1;
-  return fibo(n, memo);
+  let v1 = 0, v2 = 1;
+  for (let i = 2; i <= n; i++) {
+      let sum = (v1 % 1234567 + v2 % 1234567) % 1234567;
+      v1 = v2 % 1234567;
+      v2 = sum;
+  }
+  return v2;
 }

--- a/PG/Lv2/피보나치 수.js
+++ b/PG/Lv2/피보나치 수.js
@@ -1,0 +1,15 @@
+function fibo(n, memo) {
+  if (n === 0 || n === 1) return n;
+
+  if (memo[n - 1] === -1) memo[n - 1] = fibo(n - 1, memo);
+  if (memo[n - 2] === -1) memo[n - 2] = fibo(n - 2, memo);
+  
+  return (memo[n - 1] % 1234567 + memo[n - 2] % 1234567) % 1234567;
+}
+
+function solution(n) {
+  let memo = Array.from({length: n}, () => -1);
+  memo[0] = 0;
+  memo[1] = 1;
+  return fibo(n, memo);
+}


### PR DESCRIPTION
## 문제
- close #136 
- https://school.programmers.co.kr/learn/courses/30/lessons/12945

## 공부한 개념
- 자바스크립트의 Number 범위
실제 정수 계산 가능 범위는 -(2^53 - 1) ~ (2^53 - 1)
이는 Number의 MAX_SAFE_INTEGER 와 MIN_SAFE_INTEGER 값의 범위이다.
```
Number.MAX_SAFE_INTEGER ~ Number.MIN_SAFE_INTEGER
= 9007199254740991 ~ -9007199254740991
= -(2^53 - 1) ~ (2^53 - 1)
```

## 참고 레퍼런스
- [Javascript Number 범위](http://ouoiouoi.blogspot.com/2017/05/javascript-number.html)

## 후기
처음에는 재귀로 풀었다. 
근데 테스트 케이스 7~14번이 실패, 13~14번이 런타임 에러가 나서 계속 고민하다 [힌트](https://school.programmers.co.kr/learn/courses/14743?itm_content=lesson12945)를 봤다.

먼저 테스트 케이스 7~14번 실패는 **오버플로우** 문제였다.
n이 매우 큰 경우 n의 피보나치 수는 언어가 표현할 수 있는 자료형의 범위를 넘어가서 오버플로우가 발생한다.
힌트가 제시한 답변은 모든 단계에서 % 연산을 사용하는 것이었다.
```
🔖TIP [나머지 연산의 성질]

나머지 연산은 다음과 같은 특징을 갖고 있습니다

(a + b) % m = ((a % m) + (b % m)) % m
이를 문제에 적용하면 다음과 같습니다

F(n) % m 
= (F(n-1) + F(n-2)) % m
= (F(n-1) % m + F(n-2) % m) % m
```

테스트 케이스 13~14번 런타임 에러는 재귀 호출의 깊이가 너무 깊어졌기 때문이었다.
자바스크립트는 타 언어에 비해 최대 재귀 호출 깊이가 작다.
파이썬 같은 경우는 재귀 호출의 깊이 제한을 늘리는 방법이 있는데 자바스크립트는 없는 것 같다.
그래서 그냥 **재귀 호출 대신에 반복문을 사용**해야 한다.
