### PR TITLE
PG/Lv2/튜플 (정규표현식 - 그룹)

### DIFF
--- a/PG/Lv2/튜플.js
+++ b/PG/Lv2/튜플.js
@@ -1,0 +1,16 @@
+function solution(s) {
+  let answer = [];
+
+  s = s.slice(2, -2).split(/},{/g).sort((a, b) => a.length - b.length);
+  for (let i = 0; i < s.length; i++) {
+      let list = s[i].split(',');
+      for (let j = 0; j < list.length; j++) {
+          const n = Number(list[j]);
+          if (!answer.includes(n)) {
+              answer.push(n);
+              break;
+          }
+      }
+  }
+  return answer;
+}


### PR DESCRIPTION
## 문제
- close #162 
- https://school.programmers.co.kr/learn/courses/30/lessons/64065

## 참고 레퍼런스
- [정규표현식, 이렇게 시작하자!](https://heropy.blog/2018/10/28/regexp/)

## 후기
정규표현식에 대한 이해가 아직 부족하다. 
```c
// s = "{{20,111},{111}}"
console.log(s.match(/(\d+,)*\d+/g)); // [ '20,111', '111' ]
```
위는 다른 사람의 풀이에서 발견한 정규표현식이다.
숫자가 한 개 이상이고 뒤에 쉼표가 붙은 것을 그룹으로 묶었고 이것은 있을 수도 있고 없을 수도 있다. 
그 뒤에 숫자가 한 개 이상 꼭 와야 한다. 

**그룹이란?**
```c
const ko = 'kokokoko';
const koooo = 'kooookoooo';

ko.match(/ko+/);
// ["ko", index: 0, input: "kokokoko", groups: undefined]
koooo.match(/ko+/);
// ["koooo", index: 0, input: "kooookoooo", groups: undefined]

ko.match(/(ko)+/);
// ["kokokoko", "ko", index: 0, input: "kokokoko", groups: undefined]
koooo.match(/(ko)+/);
// ["ko", "ko", index: 0, input: "kooookoooo", groups: undefined]
```
표현식 ko+는 "k"를 검색하고 "o"를 1회 이상 연속으로 반복되는 문자로 검색한다.
그 결과로 "koooo"가 반환된다.

하지만 표현식 (ko)+는 "k"와 "o"를 묶었기(그룹화) 때문에 "ko"를 1회 이상 연속으로 반복되는 문자로 검색한다.
따라서 결과가 "kokokoko"가 반환된다.