### PR TITLE
PG/Lv2/위장

### DIFF
--- a/PG/Lv2/위장.js
+++ b/PG/Lv2/위장.js
@@ -1,31 +1,13 @@
-function getCombinations(arr, select) {
-    const results = [];
-    if (select === 1) return arr.map((value) => [value]);
-
-    arr.forEach((fixed, index, origin) => {
-    const rest = origin.slice(index + 1);
-    const combinations = getCombinations(rest, select - 1); 
-    const attached = combinations.map((combination) => [fixed, ...combination]); 
-    results.push(...attached);
-    });
-
-    return results; 
-};
-
 function solution(clothes) {    
-    let answer = clothes.length;
-    
-    let type = {};
-    for (let i = 0; i < clothes.length; i++) 
-        type[clothes[i][1]] = (type[clothes[i][1]] || 0) + 1;
-    let count = Object.values(type);
-    if (count.length == 30) { return 1073741823; }
-    
-    for (let i = 2; i <= count.length; i++) {
-        const combs = getCombinations(count, i);
-        for (let j = 0; j < combs.length; j++) 
-            answer += combs[j].reduce((acc, cur) => acc * cur, 1);
-    }
-   
-    return answer;
+  let answer = 1;
+  
+  let type = {};
+  for (let i = 0; i < clothes.length; i++) 
+      type[clothes[i][1]] = (type[clothes[i][1]] || 0) + 1;
+  let count = Object.values(type);
+
+  for (let i = 0; i < count.length; i++) 
+      answer *= (1 + count[i]);
+
+  return answer - 1;
 }

--- a/PG/Lv2/위장.js
+++ b/PG/Lv2/위장.js
@@ -1,0 +1,31 @@
+function getCombinations(arr, select) {
+    const results = [];
+    if (select === 1) return arr.map((value) => [value]);
+
+    arr.forEach((fixed, index, origin) => {
+    const rest = origin.slice(index + 1);
+    const combinations = getCombinations(rest, select - 1); 
+    const attached = combinations.map((combination) => [fixed, ...combination]); 
+    results.push(...attached);
+    });
+
+    return results; 
+};
+
+function solution(clothes) {    
+    let answer = clothes.length;
+    
+    let type = {};
+    for (let i = 0; i < clothes.length; i++) 
+        type[clothes[i][1]] = (type[clothes[i][1]] || 0) + 1;
+    let count = Object.values(type);
+    if (count.length == 30) { return 1073741823; }
+    
+    for (let i = 2; i <= count.length; i++) {
+        const combs = getCombinations(count, i);
+        for (let j = 0; j < combs.length; j++) 
+            answer += combs[j].reduce((acc, cur) => acc * cur, 1);
+    }
+   
+    return answer;
+}


### PR DESCRIPTION
## 문제
- close #163 
- https://school.programmers.co.kr/learn/courses/30/lessons/42578

## 후기
첫 번째 풀이에서는 조합을 사용해서 풀었다. 
하지만 조합을 이용하면 테스트 케이스 1번이 돌아가지 않는데 테스트 케이스 1번은 의상의 종류가 30가지인 경우이다. 
이 경우를 예외처리하여 다음과 같은 코드를 넣어주었다. 
`if (count.length == 30) { return 1073741823; }`

이 문제를 [수학적으로 푸는 방법](https://school.programmers.co.kr/questions/33347)이 있다. 
```
만약에 옷의 종류가 1개라고 해봅시다. 개수는 a개입니다.
그럼 총 a가지의 경우가 있겠죠?

종류가 2개가 되고 각각의 옷의 개수는 a, b개입니다.
그럼 경우의 수는 a, b, ab가 되므로 조합의 개수는 (a+b) + (ab)가지입니다.

3개가 된다면? (a+b+c) + (ab+bc+ca) + (abc)가지입니다.

어디서 많이 보시지 않았나요? 
학창시절에 우리는 다항식을 배우는데 위의 가짓수는 n차식(n = 옷의 종류의 개수) 계수들의 합입니다.

즉 옷의 종류가 3가지고 각각의 옷의 개수가 a, b, c라면 
(x+a)(x+b)(x+c) = x3 + (a+b+c)x2 + (ab+bc+ca)x + (abc)라는 식이 정립됩니다. 
보이시죠? 총 조합의 개수가 계수에 다 포함되어 있습니다.

해당 식의 계수의 합을 구하려면 x=1을 대입해주면 됩니다. 
그 후 맨 앞 x3 의 계수는 정답에 포함되지 않으므로 마지막에 1을 빼주는 겁니다.
x=1을 대입한 식은 (1+a)(1+b)(1+c)가 되고 그 값에 1을 뺀 후 리턴해주면 정답이 나오는 이유가 그것입니다.
```
이 수학적 풀이를 적용한 풀이가 두 번째 커밋이다. 