### PR TITLE
BOJ/S1/곱셈 (BigInt)

### DIFF
--- a/BOJ/Silver/곱셈.js
+++ b/BOJ/Silver/곱셈.js
@@ -1,0 +1,24 @@
+function solution(a, b, c) {
+  if (b === 1) return a % c;
+
+  let val = solution(a, Math.floor(b / 2), c);
+  val = (val * val) % c;
+  return b % 2 ? (val * a) % c : val;
+}
+
+const fs = require("fs");
+const input = (
+  process.platform === "linux"
+    ? fs.readFileSync("/dev/stdin").toString()
+    : fs.readFileSync("input.txt").toString()
+)
+  .trim()
+  .split(" ")
+  .map((e) => +e);
+let [a, b, c] = input;
+
+a = BigInt(a);
+c = BigInt(c);
+
+console.log(solution(a, b, c).toString());
+


### PR DESCRIPTION
## 문제
- close #264 
- https://www.acmicpc.net/problem/1629

## 공부한 개념
- BigInt
  BigInt는 정수 리터럴의 뒤에 n을 붙이거나(10n) 함수 BigInt()를 호출해 생성할 수 있다. 
BigInt를 출력할 때에는 toString()으로 출력해야 한다. 그렇지 않다면 끝에 n이 붙어서 나온다.

참고로 자바스크립트 기본 Number 자료형의 최대 크기는 2^53 - 1이다.

## 참고 레퍼런스
- [MDN - BigInt](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/BigInt)

## 후기
재귀 문제
어렵기도 했지만... BigInt때문에 더 삽질함............

a와 c를 BigInt로 뒀다.
val은 a와 c의 연산 결과이므로 BigInt 타입이 된다. 
val이 Number의 최대값을 넘을 수 있기 때문에 BigInt 타입으로 만들어줘야 한다고 이해했다.

val만 BigInt로 만드는 것을 생각해봤는데 val과 a와 c가 연산이 필요하기 때문에 그냥 a와 c를 BigInt로 만드는 게 맞는 것 같다.